### PR TITLE
Update dependencies

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -10,7 +10,7 @@
   <!--[if lt IE 9]>
   <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
-  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.css" />
+  <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
   <style>
   #map,body,html{
     height:100%;
@@ -23,9 +23,9 @@
 
 <body>
   <div id="map"></div>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/topojson/1.6.19/topojson.min.js"></script>
-  <script src="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
+  <script src="../node_modules/d3/d3.min.js"></script>
+  <script src="../node_modules/topojson-client/dist/topojson-client.min.js"></script>
+  <script src="../node_modules/leaflet/dist/leaflet.js"></script>
   <script src="../src/Control.GlobeMiniMap.js"></script>
   <script>
     var layer = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "topojson-client": "^3.0.0"
   },
   "devDependencies": {
-    "uglify-js": "2.4.16"
+    "uglify-js": "^2.8.0"
   },
   "scripts": {
     "build:js": "uglifyjs  --output dist/Control.MiniMap.min.js src/Control.MiniMap.js",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,7 @@
     "leaflet": ">=0.7.3"
   },
   "devDependencies": {
-    "uglify-js": "2.4.16",
-    "clean-css": "3.0.7",
-    "ncp": "1.0.1",
-    "svgo": "0.5.0",
-    "svg2png": "1.1.0"
+    "uglify-js": "2.4.16"
   },
   "scripts": {
     "build:js": "uglifyjs  --output dist/Control.MiniMap.min.js src/Control.MiniMap.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "url": "https://github.com/chriswhong/leaflet-globe-minimap.git/issues"
   },
   "dependencies": {
-    "leaflet": ">=0.7.3"
+    "d3": "^3.5.0",
+    "leaflet": ">=0.7.3",
+    "topojson-client": "^3.0.0"
   },
   "devDependencies": {
     "uglify-js": "2.4.16"


### PR DESCRIPTION
This PR adds leaflet and d3 as explicit dependencies in `package.json`; upgrades leaflet, topojson(-client), and uglify-js to current releases; and adjusts `example/index.html` to load dependencies from `node_modules`. (This last change probably doesn't work well with the gh-pages branch, so maybe it's not worth keeping?)

I tried to upgrade d3 to v4+. The API changes aren't that severe (really just the `geo` stuff), but the d3 packages (`d3`, `d3-geo`, etc) no longer include compiled JS in the packages -- so doing a clean upgrade will mean converting this package to use ES modules and Webpack/Rollup/whatever.

If #6 is merged it'll be easy to move forward with the d3 upgrade, because the example can load a JS bundle from `dist/` instead of directly from `src/`.